### PR TITLE
Microsoft azure-cli image as base

### DIFF
--- a/test/runtime/Dockerfile
+++ b/test/runtime/Dockerfile
@@ -21,9 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /azurecli ./test/plugins/azurecli.go
 # Python so we can install azure cli
 FROM mcr.microsoft.com/azure-cli
 
-# Install Python
 WORKDIR /app
-
 
 COPY --from=builder /runtime ./runtime
 COPY --from=builder /busy ./plugins/busy/1.0.0/busy

--- a/test/runtime/Dockerfile
+++ b/test/runtime/Dockerfile
@@ -19,14 +19,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /azurecli ./test/plugins/azurecli.go
 
 # Use a minimal base image to package the runtime binary
 # Python so we can install azure cli
-FROM python:alpine
+FROM mcr.microsoft.com/azure-cli
 
 # Install Python
 WORKDIR /app
 
-RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
-RUN pip install --upgrade pip
-RUN pip install azure-cli
 
 COPY --from=builder /runtime ./runtime
 COPY --from=builder /busy ./plugins/busy/1.0.0/busy


### PR DESCRIPTION
Whilst we could base our image off of the dockerfile (which is now gone), the official advice here:

https://github.com/Azure/azure-cli/issues/19591

Is to simply base our image from theres as apparently it is based on Alpine, and means we don't need to have any Python stuff replicated in our file which was causing some issues

Image still comes out at ~700MB though so could be worth investigating why.  (the reason is microsoft....)